### PR TITLE
Add the sqlToTSQuery function

### DIFF
--- a/src/Opaleye/Internal/PGTypesExternal.hs
+++ b/src/Opaleye/Internal/PGTypesExternal.hs
@@ -190,6 +190,10 @@ pgTSVector (C.Column e) = C.Column (HPQ.FunExpr "tsvector" [e])
 pgTSQuery :: Field SqlText -> Field SqlTSQuery
 pgTSQuery (C.Column e) = C.Column (HPQ.FunExpr "tsquery" [e])
 
+-- | Converts a 'String' into a Postgres' tsQuery by calling 'to_tsquery' on the input string.
+to_pgTSQuery :: String -> Field SqlTSQuery
+to_pgTSQuery query = C.Column (HPQ.FunExpr "to_tsquery" [HPQ.ConstExpr (HPQ.StringLit query)])
+
 
 instance IsSqlType SqlBool where
   showSqlType _ = "boolean"

--- a/src/Opaleye/SqlTypes.hs
+++ b/src/Opaleye/SqlTypes.hs
@@ -93,7 +93,8 @@ module Opaleye.SqlTypes (
 
   P.SqlTSQuery,
   P.SqlTSVector,
-  sqlTSQuery
+  sqlTSQuery,
+  sqlToTSQuery
   ) where
 
 import qualified Opaleye.Field   as F
@@ -213,6 +214,9 @@ sqlValueJSON = P.pgValueJSON
 
 sqlTSQuery :: String -> F.Field P.SqlTSQuery
 sqlTSQuery = P.pgTSQuery . sqlString
+
+sqlToTSQuery :: String -> F.Field P.SqlTSQuery
+sqlToTSQuery = P.to_pgTSQuery
 
 -- The jsonb data type was introduced in PostgreSQL version 9.4
 -- JSONB values must be SQL string quoted


### PR DESCRIPTION
This commits adds a variant to the tsquery stuff called `sqlToTSQuery`, which desugars to the `to_tsquery` Postgres function, which can parse a string into a valid `tsquery`. This typically yields better results then just trying to coerce a string into a `::tsquery` (via casting) because it deals automatically with things like case sensitivity etc. Compare a search on some Arxiv Haskell results by Author:

![Screenshot 2023-09-11 at 09 26 22](https://github.com/garganscript/haskell-opaleye/assets/442035/d87e9cbd-b720-4968-b118-05aabd2dc177)

![Screenshot 2023-09-11 at 09 26 40](https://github.com/garganscript/haskell-opaleye/assets/442035/aae707ce-af79-4677-a367-5c05622ea063)

As you can see using `to_tsquery` yields the expected results, whereas in the first case it doesn't (but it works if one uses `raphael` all lowercase, as input).